### PR TITLE
fixes MyUNiDAYS#39

### DIFF
--- a/src/scss/layout.scss
+++ b/src/scss/layout.scss
@@ -39,6 +39,7 @@ body
         page-break-inside: avoid;           /* Theoretically FF 20+ */
         break-inside: avoid-column;         /* IE 11 */
         display:table;                      /* Actually FF 20+ */
+        transform: translateZ(0);           /* Seems a bit of a hack, but fixes the issue with clipped shadows in columns in Chromium browsers - @rdunn418 */
     }
 }
 

--- a/src/scss/nav.scss
+++ b/src/scss/nav.scss
@@ -10,6 +10,7 @@ body
         box-sizing: border-box;
         height: 70px;
         box-shadow: rgba(0, 0, 0, 0.4) 0 0 5px;
+        z-index: 1; /* Ensure navbar stuff appears on top of other elements when using the drop shadow bug fix - @rdunn418 */
 
         .logo 
         {


### PR DESCRIPTION
Kind of a weird hacky solution, but the drop shadow thing was down to a bug in the Chromium renderer when dealing with columns. I found out that adding a CSS transform that visually doesn't do anything (in this case translatez(0)) onto the box class seems to render it correctly for some reason. The transform messes with the z ordering though so I had to make sure the navigation bar had a z-index of 1. Unless there are any unforseen consequences with it, this seems to work ok.