### PR TITLE
grunt-sass-globbing fix for scss auto import issue #1

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -105,6 +105,14 @@ module.exports = function (grunt) {
                 tasks: ['generate']
             }
           },
+            sass_globbing: {
+                     target: {
+                      files: {
+                          'src/scss/styles.scss' : 'src/scss/*'
+                      },
+                }
+            },
+
           concurrent: {
             options: {
                 logConcurrentOutput: true
@@ -122,6 +130,7 @@ module.exports = function (grunt) {
       grunt.loadNpmTasks('grunt-contrib-clean');
       grunt.loadNpmTasks('grunt-concurrent');
       grunt.loadNpmTasks('grunt-express');
+      grunt.loadNpmTasks('grunt-sass-globbing')
       
       grunt.registerTask('server', ['express', 'express-keepalive']);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2137,6 +2137,12 @@
       "integrity": "sha512-Ogq4cWqBre71gZIkgxIxevgzZHSIIsrKu/5yvPDl4Mvib0A4TRTJEQUdpQ0YV1iai0DPjayz02vDJE6KUVHQ2w==",
       "dev": true
     },
+    "grunt-sass-globbing": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/grunt-sass-globbing/-/grunt-sass-globbing-1.5.1.tgz",
+      "integrity": "sha1-nmCVXNjLP0lt3QfPcc+UQFsjgtE=",
+      "dev": true
+    },
     "gzip-size": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "grunt-express": "^1.4.1",
         "grunt-parallel": "^0.5.1",
         "grunt-sass": "^3.0.2",
+        "grunt-sass-globbing": "^1.5.1",
         "handlebars": "^4.1.2",
         "jsdom": "^15.1.1",
         "md5": "^2.2.1",

--- a/src/scss/common.scss
+++ b/src/scss/common.scss
@@ -73,3 +73,13 @@ a.button
     display: block;
     line-height: 1;
 }
+
+footer{
+    position: fixed;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    background-color: #f2f2f2;
+    color: #999999;
+
+}

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -1,1 +1,1 @@
-@import 'variables', 'reset', 'fonts', 'layout', 'nav', 'common', 'accordion', 'tables', 'box', 'forms';
+@import 'styles';

--- a/src/templates/index.hbs
+++ b/src/templates/index.hbs
@@ -108,5 +108,6 @@
         {{> competencies competencies }}
         {{> roles roles }}
     </section>
+    <footer>Copyright &copy UNiDAYS. All Rights Reserved.   <a href="https://www.myunidays.com/GB/en-GB/terms-of-service">Terms of Service</a></footer>
 </body>
 </html>


### PR DESCRIPTION
I added grunt-sass-globbing fix to allow for auto importing of scss files by importing a whole folder of files with one short single statement instead of having to add multiple scss files individually within the styles.scss sheet.

Details of the fix are under url: https://www.npmjs.com/package/grunt-sass-globbing/v/1.0.3